### PR TITLE
Coherent ref

### DIFF
--- a/server/app/services/api_services.py
+++ b/server/app/services/api_services.py
@@ -116,7 +116,7 @@ def get_ripe_format(measurement: RipeMeasurement) -> dict[str, Any]:
     """
     probe_location: Optional[ServerLocation] = measurement.probe_data.probe_location
     # this code regarding ref_id is because we need to consider IPv6 cases (M5 hashes involved)
-    ref_id_str = "NO REFERENCE"
+    ref_id_str: str | None = "NO REFERENCE"
     try:
         ref_ip, ref_text = ref_id_to_ip_or_name(int(measurement.ref_id), measurement.ntp_measurement.main_details.stratum,
                                           get_ip_family(ip_to_str(measurement.ntp_measurement.server_info.ntp_server_ip)))

--- a/server/app/services/api_services.py
+++ b/server/app/services/api_services.py
@@ -1,6 +1,6 @@
 from sqlalchemy.orm import Session
 
-from app.utils.ip_utils import get_ip_family, ref_id_to_ip_or_name
+from server.app.utils.ip_utils import get_ip_family, ref_id_to_ip_or_name
 from server.app.utils.location_resolver import get_asn_for_ip
 from server.app.utils.ip_utils import is_this_ip_anycast
 from server.app.utils.perform_measurements import perform_ntp_measurement_domain_name_list

--- a/server/app/services/api_services.py
+++ b/server/app/services/api_services.py
@@ -1,5 +1,6 @@
 from sqlalchemy.orm import Session
 
+from app.utils.ip_utils import get_ip_family, ref_id_to_ip_or_name
 from server.app.utils.location_resolver import get_asn_for_ip
 from server.app.utils.ip_utils import is_this_ip_anycast
 from server.app.utils.perform_measurements import perform_ntp_measurement_domain_name_list
@@ -114,6 +115,17 @@ def get_ripe_format(measurement: RipeMeasurement) -> dict[str, Any]:
                 - NTP measurement data (rtt, offset, timestamps)
     """
     probe_location: Optional[ServerLocation] = measurement.probe_data.probe_location
+    # this code regarding ref_id is because we need to consider IPv6 cases (M5 hashes involved)
+    ref_id_str = "NO REFERENCE"
+    try:
+        ref_ip, ref_text = ref_id_to_ip_or_name(int(measurement.ref_id), measurement.ntp_measurement.main_details.stratum,
+                                          get_ip_family(ip_to_str(measurement.ntp_measurement.server_info.ntp_server_ip)))
+        if ref_ip is not None:
+            ref_id_str = ip_to_str(ref_ip)
+        elif ref_text is not None:
+            ref_id_str = ref_text
+    except Exception as e: #if ref_id could not be converted to an integer (ex: it was already a str)
+        ref_id_str = measurement.ref_id
     return {
         "ntp_version": measurement.ntp_measurement.server_info.ntp_version,
         "vantage_point_ip": ip_to_str(measurement.ntp_measurement.vantage_point_ip),
@@ -142,7 +154,7 @@ def get_ripe_format(measurement: RipeMeasurement) -> dict[str, Any]:
         "root_dispersion": NtpCalculator.calculate_float_time(
             measurement.ntp_measurement.extra_details.root_dispersion),
         "asn_ntp_server": get_asn_for_ip(str(measurement.ntp_measurement.server_info.ntp_server_ip)),
-        "ref_id": measurement.ref_id,
+        "ref_id": ref_id_str,
         "result": [
             {
                 "client_sent_time": {

--- a/server/app/utils/ip_utils.py
+++ b/server/app/utils/ip_utils.py
@@ -2,7 +2,6 @@ import ipaddress
 import os
 import random
 import socket
-import struct
 from ipaddress import ip_address, IPv4Address, IPv6Address
 from typing import Optional
 import ntplib

--- a/server/app/utils/ip_utils.py
+++ b/server/app/utils/ip_utils.py
@@ -36,13 +36,14 @@ def ref_id_to_ip_or_name(ref_id: int, stratum: int) \
         # from ntplib, but without "Unidentified reference source" part
         fields = (ref_id >> 24 & 0xff, ref_id >> 16 & 0xff,
                   ref_id >> 8 & 0xff, ref_id & 0xff)
-        text = "%c%c%c%c" % fields
+        text = ("%c%c%c%c" % fields).rstrip("\00")
         if text in ntplib.NTP.REF_ID_TABLE:
             return None, ntplib.NTP.REF_ID_TABLE[text]
         else:
             return None, text  # ntplib.ref_id_to_text(ref_id, stratum)
     else:
         if stratum < 256:  # we can get an IP address
+            # obs, need to consider IPv6 with that M5 part
             return ip_address(socket.inet_ntoa(ref_id.to_bytes(4, 'big'))), None  # 'big' is from big endian
         else:
             return None, None  # invalid stratum!!

--- a/server/app/utils/perform_measurements.py
+++ b/server/app/utils/perform_measurements.py
@@ -115,7 +115,7 @@ def convert_ntp_response_to_measurement(response: ntplib.NTPStats, server_ip_str
         if vantage_point_ip_temp is not None:
             vantage_point_ip = vantage_point_ip_temp
         ref_ip, ref_name = ref_id_to_ip_or_name(response.ref_id,
-                                                response.stratum)
+                                                response.stratum, get_ip_family(server_ip_str))
         server_ip = ip_address(server_ip_str)
         server_info: NtpServerInfo = NtpServerInfo(
             ntp_version=ntp_version,

--- a/server/tests/unit_tests/test_ip_utils.py
+++ b/server/tests/unit_tests/test_ip_utils.py
@@ -13,16 +13,32 @@ def test_ip_to_str():
     assert ip_to_str(IPv6Address("2001:db8:3333:4444:5555:6666:7777:8888")) == "2001:db8:3333:4444:5555:6666:7777:8888"
     assert ip_to_str(None) is None
 
+def test_ref_id_to_ip_or_name_stratum01():
+    ip, name = ref_id_to_ip_or_name(0x4e54534e, 0, 4)
+    assert ip is None
+    assert name == "NTSN"
+
+    ip, name = ref_id_to_ip_or_name(0x4e54534e, 1, 6)
+    assert ip is None
+    assert name == "NTSN"
 
 def test_ref_id_to_ip_or_name():
-    ip, name = ref_id_to_ip_or_name(1590075150, 2)
+    ip, name = ref_id_to_ip_or_name(1590075150, 2, 4)
     assert ip == IPv4Address('94.198.159.14')
     assert name is None
 
-    ip, name = ref_id_to_ip_or_name(1590075150, 2000)
+    ip, name = ref_id_to_ip_or_name(1590075150, 2000, 4)
     assert ip is None
     assert name is None
 
+def test_ref_id_to_ip_or_name_ipv6():
+    ip, name = ref_id_to_ip_or_name(1590075150, 2, 6)
+    assert ip is None
+    assert name == "IPv6 MD5 hash: 0x5ec69f0e"
+
+    ip, name = ref_id_to_ip_or_name(1590075150, 2000, 6)
+    assert ip is None
+    assert name is None
 
 def test_get_ip_family():
     assert get_ip_family("189.24.80.23") == 4


### PR DESCRIPTION
Regarding #20 
I updated the method to convert the raw reference ID from RIPE Atlas to text/IP. 

The reference IDs from RIPE measurements also use this method now. (they no longer show raw data)

Besides, I noticed that ntplib did not consider ref Ids from IPv6 address, so I needed to take care of this case.
I considered the IPv6 ref ids with stratum>1 case, where the reference ID is an M5 hash (According to RFC 5905 7.3). In this case (and only in this case) the method returns a small warning that it is a hash together with the hex data of that hash. I found out it was incorrect to convert that hash into an IPv4 address.

From RFC 5905:
 "Above stratum 1 (secondary servers and clients): this is the
   reference identifier of the server and can be used to detect timing
   loops.  If using the IPv4 address family, the identifier is the four-
   octet IPv4 address.  If using the IPv6 address family, it is the
   first four octets of the MD5 hash of the IPv6 address.  Note that,
   when using the IPv6 address family on an NTPv4 server with a NTPv3
   client, the Reference Identifier field appears to be a random value
   and a timing loop might not be detected."
